### PR TITLE
Try to fix #6, IndexError

### DIFF
--- a/smart_fact_crawler/__init__.py
+++ b/smart_fact_crawler/__init__.py
@@ -13,30 +13,31 @@ smartfacturl = "http://fact-project.org/smartfact/data/"
 
 
 class TableCrawler(object):
-    connection_error_counter = defaultdict(int)
-
     def __init__(self, url):
-        self._request_web_page(url)
-        self._build_page_payload()
+        self.url = url
+        self.connection_error_counter = 0
+        self._load_payload()
 
     def __getitem__(self, index):
         row, col = index
-        item = self.page_payload[row][col]
-        return item
-
-    def _request_web_page(self, url):
         while True:
             try:
-                self.web_page = requests.get(url, timeout=15.)
-            except requests.exceptions.ConnectionError:
-                self.connection_error_counter[url] += 1
-                if self.connection_error_counter[url] >= 10:
-                    raise
-                else:
-                    # sleep between 1 and 2 seconds.
-                    time.sleep(1. + random.random())
+                item = self.page_payload[row][col]
+            except IndexError:
+                self._acknowledge_error_and_wait_a_moment()
             else:
-                self.connection_error_counter[url] = 0
+                self.connection_error_counter = 0
+                break
+        return item
+
+    def _request_web_page(self):
+        while True:
+            try:
+                self.web_page = requests.get(self.url, timeout=15.)
+            except requests.exceptions.ConnectionError:
+                self._acknowledge_error_and_wait_a_moment()
+            else:
+                self.connection_error_counter = 0
                 break
 
     def _build_page_payload(self):
@@ -45,6 +46,18 @@ class TableCrawler(object):
             for line in self.web_page.text.splitlines()
         ]
 
+    def _load_payload(self):
+        self._request_web_page()
+        self._build_page_payload()
+
+    def _acknowledge_error_and_wait_a_moment(self):
+        print('acknowledge_error')
+        self.connection_error_counter += 1
+        if self.connection_error_counter >= 10:
+            raise
+        else:
+            # sleep between 1 and 2 seconds.
+            time.sleep(1. + random.random())        
 
 def str2float(text):
     try:

--- a/smart_fact_crawler/__init__.py
+++ b/smart_fact_crawler/__init__.py
@@ -51,7 +51,6 @@ class TableCrawler(object):
         self._build_page_payload()
 
     def _acknowledge_error_and_wait_a_moment(self):
-        print('acknowledge_error')
         self.connection_error_counter += 1
         if self.connection_error_counter >= 10:
             raise

--- a/smart_fact_crawler/__init__.py
+++ b/smart_fact_crawler/__init__.py
@@ -18,37 +18,24 @@ class TableCrawler(object):
         self.connection_error_counter = 0
         self._load_payload()
 
-    def __getitem__(self, index):
-        row, col = index
-        while True:
-            try:
-                item = self.page_payload[row][col]
-            except IndexError:
-                self._acknowledge_error_and_wait_a_moment()
-            else:
-                self.connection_error_counter = 0
-                break
-        return item
+    def _load_payload(self):
+        self._request_web_page()
+        self._build_page_payload()
 
     def _request_web_page(self):
         while True:
             try:
                 self.web_page = requests.get(self.url, timeout=15.)
-            except requests.exceptions.ConnectionError:
-                self._acknowledge_error_and_wait_a_moment()
-            else:
                 self.connection_error_counter = 0
                 break
+            except requests.exceptions.ConnectionError:
+                self._acknowledge_error_and_wait_a_moment()
 
     def _build_page_payload(self):
         self.page_payload = [
             [html.unescape(elem) for elem in line.split('\t')]
             for line in self.web_page.text.splitlines()
         ]
-
-    def _load_payload(self):
-        self._request_web_page()
-        self._build_page_payload()
 
     def _acknowledge_error_and_wait_a_moment(self):
         self.connection_error_counter += 1
@@ -57,6 +44,18 @@ class TableCrawler(object):
         else:
             # sleep between 1 and 2 seconds.
             time.sleep(1. + random.random())        
+
+    def __getitem__(self, index):
+        row, col = index
+        while True:
+            try:
+                item = self.page_payload[row][col]
+                self.connection_error_counter = 0
+                break
+            except IndexError:
+                self._acknowledge_error_and_wait_a_moment()
+        return item
+
 
 def str2float(text):
     try:


### PR DESCRIPTION
If an IndexError is raised while accessing the TableCrawler, most likely because the smart fact web page is corrupted, the TableCrawler will try to reload the page just as it is done on connection problems. After 10 trails, finally an exception is raised.  