### PR TITLE
Fix no magic weather

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
-- '3.5'
+  - '3.5'
 install:
-- pip install -r requirements.txt
-- pip install .
+  - pip install -r requirements.txt
+  - pip install .
+  - pip install pyflakes
 script:
-- py.test
+  - pyflakes smart_fact_crawler
+  - python setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[aliases]
+test = pytest
+
+[tool:pytest]
+addopts = --verbose

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(
@@ -12,7 +12,7 @@ setup(
     packages=[
         'smart_fact_crawler',
     ],
-   package_data={'smart_fact_crawler': [
+    package_data={'smart_fact_crawler': [
                 'resources/20160703_233149/*.data',
                 'resources/20160703_233149_broken_fsc/fsc.data',
                 ]
@@ -20,5 +20,7 @@ setup(
     install_requires=[
         'requests',
     ],
+    tests_require=['pytest>=3.0'],
+    setup_requires=['pytest-runner'],
     zip_safe=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='smart_fact_crawler',
-    version='0.2.1',
+    version='0.2.2',
     description='acquieres data published on the smartfact web page',
     url='https://github.com/fact-project/smart_fact_crawler.git',
     author='Dominik Neise, Sebastian Mueller, Maximilian Nöthe',
@@ -12,10 +12,11 @@ setup(
     packages=[
         'smart_fact_crawler',
     ],
-    package_data={'smart_fact_crawler': [
-                'resources/20160703_233149/*.data',
-                'resources/20160703_233149_broken_fsc/fsc.data',
-                ]
+    package_data={
+        'smart_fact_crawler': [
+            'resources/20160703_233149/*.data',
+            'resources/20160703_233149_broken_fsc/fsc.data',
+         ]
     },
     install_requires=[
         'requests',

--- a/smart_fact_crawler/__init__.py
+++ b/smart_fact_crawler/__init__.py
@@ -258,13 +258,22 @@ def main_page(url=None):
     if url is None:
         url = os.path.join(smartfacturl, 'fact.data')
     table = smartfact2table(url)
+
+    try:
+        humidity = Quantity(s2f(table[4][1]), '%')
+        wind_speed = Quantity(s2f(table[4][2]), 'km/h')
+    except IndexError:
+        humidity = Quantity(float('nan'), '%')
+        wind_speed = Quantity(float('nan'), 'km/h')
+
+
     return to_namedtuple('MainPage', {
         'timestamp_1': sft2dt(table[0][0]),
         'timestamp_2': sft2dt(table[0][1]),
         'system_status': table[1][1],
         'relative_camera_temperature': Quantity(s2f(table[3][1]), 'deg_C'),
-        'humidity': Quantity(s2f(table[4][1]), '%'),
-        'wind_speed': Quantity(s2f(table[4][2]), 'km/h'),
+        'humidity': humidity,
+        'wind_speed': wind_speed,
     })
 
 

--- a/smart_fact_crawler/tests/test_functional.py
+++ b/smart_fact_crawler/tests/test_functional.py
@@ -1,7 +1,7 @@
 from os import path
 import smart_fact_crawler as sfc
 from datetime import datetime
-from pprint import pprint
+
 
 def test_is_install_folder_a_directory():
     dir_ = path.dirname(sfc.__file__)
@@ -27,7 +27,7 @@ def test_smartfact():
         'resources',
         '20160703_233149',
         )
-    
+
     sfc.smartfact()
 
 def test_timestamp_dates():
@@ -37,13 +37,13 @@ def test_timestamp_dates():
         '20160703_233149',
         )
     test_date = datetime(2016, 7, 3).date()
-    
+
     complete = sfc.smartfact()
 
     for page_name in complete._asdict():
         page = complete._asdict()[page_name]
         for row_name in page._asdict():
-            row = page._asdict()[row_name]            
+            row = page._asdict()[row_name]
             if 'timestamp' in row_name:
                 assert row.date() == test_date
 


### PR DESCRIPTION


This fixes the issue of an index error for the main smartfact page that occures when magic weather is not reachable. Then smartfact only displays `---` instead of the tuple humidity / wind.

I also adapted our test settings to the ones we use in pyfact, pyeventio, pycustos and the shifthelper
