### PR TITLE
Download smartfact data

### DIFF
--- a/download_smartfact_data.py
+++ b/download_smartfact_data.py
@@ -94,14 +94,20 @@ def download(url, outputfile):
         logging.error('Could not download {}'.format(url))
 
 
-def download_all():
-    logging.info('Start downloading all')
+def make_output_dir():
     now = datetime.utcnow()
 
     output_directory = '{}/{:02d}/{:02d}/{:%H%M}'.format(
         now.year, now.month, now.day, now
     )
     os.makedirs(output_directory, exist_ok=True)
+
+    return output_directory
+
+
+def download_all():
+    logging.info('Start downloading all')
+    output_directory = make_output_dir()
 
     with ThreadPoolExecutor(max_workers=len(files)) as executor:
         for filename in files:

--- a/download_smartfact_data.py
+++ b/download_smartfact_data.py
@@ -91,8 +91,8 @@ def download(url, outputfile):
 
         with open(outputfile, 'w') as f:
             f.write(ret.text)
-    except requests.ConnectionError:
-        logging.error('Could not download {}'.format(url))
+    except requests.exceptions.RequestException as e:
+        logging.exception('Could not download {}'.format(url))
 
 
 def make_output_dir():

--- a/download_smartfact_data.py
+++ b/download_smartfact_data.py
@@ -138,9 +138,7 @@ def download_all_without_executor():
         )
 
 if __name__ == '__main__':
-    download_all()
-
-    schedule.every(5).minutes.do(download_all)
     while True:
-        schedule.run_pending()
-        sleep(10)
+        download_all_without_executor()
+        sleep(5 * 60)
+

--- a/download_smartfact_data.py
+++ b/download_smartfact_data.py
@@ -109,7 +109,7 @@ def download_all():
                 download,
                 url.format(filename),
                 os.path.join(
-                    output_directory, '{}.data'.format(filename, now)
+                    output_directory, '{}.data'.format(filename)
                 )
             )
 

--- a/download_smartfact_data.py
+++ b/download_smartfact_data.py
@@ -126,6 +126,17 @@ def download_all():
             )
 
 
+def download_all_without_executor():
+    logging.info('Start download_all_without_executor')
+    output_directory = make_output_dir()
+    out_path = partial(make_out_path, output_directory)
+
+    for filename in files:
+        download(
+            url.format(filename),
+            out_path(filename)
+        )
+
 if __name__ == '__main__':
     download_all()
 

--- a/download_smartfact_data.py
+++ b/download_smartfact_data.py
@@ -10,7 +10,7 @@ from functools import partial
 logging.basicConfig(level=logging.INFO)
 
 
-url = 'http://fact-project.org/smartfact/data/{}.data'
+url = 'http://fact-project.org/smartfact/data/{}'
 files = [
     'agilent24.data',
     'agilent50.data',
@@ -107,9 +107,7 @@ def make_output_dir():
 
 
 def make_out_path(output_directory, filename):
-    os.path.join(
-        output_directory, '{}.data'.format(filename)
-    )
+    return os.path.join(output_directory, filename)
 
 
 def download_all():
@@ -126,19 +124,10 @@ def download_all():
             )
 
 
-def download_all_without_executor():
-    logging.info('Start download_all_without_executor')
-    output_directory = make_output_dir()
-    out_path = partial(make_out_path, output_directory)
-
-    for filename in files:
-        download(
-            url.format(filename),
-            out_path(filename)
-        )
-
 if __name__ == '__main__':
-    while True:
-        download_all_without_executor()
-        sleep(5 * 60)
+    download_all()
 
+    schedule.every(5).minutes.do(download_all)
+    while True:
+        schedule.run_pending()
+        sleep(10)

--- a/download_smartfact_data.py
+++ b/download_smartfact_data.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
 import logging
 from time import sleep
+from functools import partial
 
 logging.basicConfig(level=logging.INFO)
 
@@ -105,18 +106,23 @@ def make_output_dir():
     return output_directory
 
 
+def make_out_path(output_directory, filename):
+    os.path.join(
+        output_directory, '{}.data'.format(filename)
+    )
+
+
 def download_all():
     logging.info('Start downloading all')
     output_directory = make_output_dir()
+    out_path = partial(make_out_path, output_directory)
 
     with ThreadPoolExecutor(max_workers=len(files)) as executor:
         for filename in files:
             executor.submit(
                 download,
                 url.format(filename),
-                os.path.join(
-                    output_directory, '{}.data'.format(filename)
-                )
+                out_path(filename)
             )
 
 


### PR DESCRIPTION
I tried to use this download script, but it did not work.

I had to play around to find the problem, since somehow the exception did not bubble up.
I first broke out two functions, to be better able to read the code, found that one `format()` got two parameters while it only needed one .. format does not throw an exception in this case, it just does not use all parameters.

Then I removed the threaded stuff, so I really got the exceptions ..  I had no experience with the ThreadPoolExecutor and did not know how to do it otherwise.

Found that not only ConnectionError might be thrown, but also other requests.exceptions, so in case of any request.exception we log now.

In this case the exception was caused by wrong filenames to download. You see, I needed to remove these ".data" suffixes. 

Now it works on my machine .. .